### PR TITLE
Pin setuptools to 38.7.0.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -11,4 +11,6 @@ eggs =
 
 [versions]
 zc.buildout = >= 2.2.1
-setuptools = >= 2.2
+# FIXME: https://github.com/plone/plone.recipe.zope2instance/issues/37
+# setuptools = >= 2.2
+setuptools = 38.7.0


### PR DESCRIPTION
Wait until https://github.com/plone/plone.recipe.zope2instance/issues/37 is done to remove the pin.