### PR TITLE
Use Plone's setuptools and zc.buildout pins.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Install
     $ git clone git@github.com:collective/minimalplone4.git
     $ cd minimalplone4
     $ virtualenv .  # Make sure, it's installing Python 2.6 or 2.7
-    $ ./bin/pip install zc.buildout
+    $ ./bin/pip install -r requirements.txt
     $ ./bin/buildout
 
 - Or if you want to use the ZEO configuration::

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -8,9 +8,3 @@ recipe = plone.recipe.zope2instance
 eggs =
     Plone
     Pillow
-
-[versions]
-zc.buildout = >= 2.2.1
-# FIXME: https://github.com/plone/plone.recipe.zope2instance/issues/37
-# setuptools = >= 2.2
-setuptools = 38.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# These versions come from https://dist.plone.org/release/4-latest/versions.cfg
+setuptools==26.1.1
+zc.buildout==1.7.1


### PR DESCRIPTION
After https://github.com/collective/minimalplone4/pull/2, although using
bootstrap.py works, it fails giving a recursion error when using the
official README with virtualenv:

```Creating directory '/tmp/minimalplone4/parts'.
Creating directory '/tmp/minimalplone4/develop-eggs'.
Upgraded:
  setuptools version 38.7.0;
restarting.
Generated script '/tmp/minimalplone4/bin/buildout'.
Upgraded:
  setuptools version 38.7.0;
restarting.
Upgraded:
  setuptools version 38.7.0;
restarting.
Upgraded:
  setuptools version 38.7.0;
restarting.
Upgraded:
  setuptools version 38.7.0;
```
There's a ticket for this in https://github.com/buildout/buildout/issues/312
but it's still open.

We came to the conclusion that using the pinned Plone versions makes
more sense. When they were pinned in the first place, it was in 2014
(https://github.com/collective/minimalplone4/commit/b9949b8451d55b9dd6b027501edc129917338218#diff-a55fc4e553af13234f26342646b88e19)
and now we're more stable in that field.